### PR TITLE
Add the copyleft-elkstack cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
+
+# Special Packages.
+jdk-8u73-linux-x64.rpm

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ copyleft cookbooks
     cookbooks/copyleft-burton
     # burton is our hubot (a.k.a. Jack Burton)
 
-    cookbooks/copyleft-elastic
-    # base install of elastic stack
+    cookbooks/copyleft-elkstack
+    # base install of elk stack
     # - elastic
     # - logstash
     # - kibana

--- a/cookbooks/copyleft-elkstack/.gitignore
+++ b/cookbooks/copyleft-elkstack/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/cookbooks/copyleft-elkstack/.kitchen.yml
+++ b/cookbooks/copyleft-elkstack/.kitchen.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  - ["forwarded_port", {guest: 9200, host: 9200, auto_correct: true}]
+  - ["forwarded_port", {guest: 5600, host: 5600, auto_correct: true}]
+  - ["forwarded_port", {guest: 5044, host: 5044, auto_correct: true}]
+  - ["forwarded_port", {guest: 80, host: 8080, auto_correct: true}]
+
+
+
+# Uncomment the following verifier to leverage Inspec instead of Busser (the
+# default verifier)
+# verifier:
+#   name: inspec
+
+platforms:
+  # - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    run_list:
+      - recipe[copyleft-elkstack::default]
+    attributes:

--- a/cookbooks/copyleft-elkstack/Berksfile
+++ b/cookbooks/copyleft-elkstack/Berksfile
@@ -1,0 +1,5 @@
+source 'https://supermarket.chef.io'
+
+metadata
+
+cookbook 'yum', '~> 3.8.0'

--- a/cookbooks/copyleft-elkstack/README.md
+++ b/cookbooks/copyleft-elkstack/README.md
@@ -1,0 +1,7 @@
+# copyleft-elkstack
+
+Stand up a very basic ELK stack.
+
+Environment: CentOS 7, Using public yum repos from Elastic.
+
+Based on this article: https://www.digitalocean.com/community/tutorials/how-to-install-elasticsearch-logstash-and-kibana-elk-stack-on-centos-7

--- a/cookbooks/copyleft-elkstack/attributes/default.rb
+++ b/cookbooks/copyleft-elkstack/attributes/default.rb
@@ -1,0 +1,1 @@
+default[:logstash][:ssl_enabled] = false

--- a/cookbooks/copyleft-elkstack/chefignore
+++ b/cookbooks/copyleft-elkstack/chefignore
@@ -1,0 +1,100 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/cookbooks/copyleft-elkstack/metadata.rb
+++ b/cookbooks/copyleft-elkstack/metadata.rb
@@ -1,0 +1,10 @@
+name 'copyleft-elkstack'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+description 'Installs/Configures copyleft-elkstack'
+long_description 'Installs/Configures copyleft-elkstack'
+version '0.1.0'
+
+depends 'yum'
+depends 'chef-client'

--- a/cookbooks/copyleft-elkstack/recipes/default.rb
+++ b/cookbooks/copyleft-elkstack/recipes/default.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+include_recipe 'yum'
+
+yum_repository 'elasticseach' do
+  description 'Elasticsearch repository for 2.x packages'
+  baseurl 'http://packages.elastic.co/elasticsearch/2.x/centos'
+  gpgcheck false
+  gpgkey 'http://packages.elastic.co/GPG-KEY-elasticsearch'
+  enabled true
+end
+
+yum_repository 'logstash' do
+  description 'Logstash repository for 2.2 packages'
+  baseurl 'http://packages.elastic.co/logstash/2.2/centos'
+  gpgkey 'http://packages.elastic.co/GPG-KEY-elasticsearch'
+  gpgcheck false
+  enabled true
+end
+
+yum_repository 'kibana' do
+  description 'Kibana repository for 4.4 packages'
+  baseurl 'http://packages.elastic.co/kibana/4.4/centos'
+  gpgkey 'http://packages.elastic.co/GPG-KEY-elasticsearch'
+  gpgcheck false
+  enabled true
+end
+
+include_recipe 'copyleft-elkstack::elasticsearch'
+include_recipe 'copyleft-elkstack::logstash'
+include_recipe 'copyleft-elkstack::kibana'

--- a/cookbooks/copyleft-elkstack/recipes/elasticsearch.rb
+++ b/cookbooks/copyleft-elkstack/recipes/elasticsearch.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: elasticsearch
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+# Install Oracle java 1.8
+cookbook_file 'jdk-8u73-linux-x64.rpm'
+
+package 'jdk' do
+  source 'jdk-8u73-linux-x64.rpm'
+end
+
+package 'elasticsearch'
+
+template 'elasticsearch.yml' do
+  path '/etc/elasticsearch/elasticsearch.yml'
+  content 'elasticsearch.yml.rb'
+  owner 'elasticsearch'
+  group 'elasticsearch'
+end
+
+service 'elasticsearch' do
+  action [:enable, :start]
+end

--- a/cookbooks/copyleft-elkstack/recipes/filebeat.rb
+++ b/cookbooks/copyleft-elkstack/recipes/filebeat.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: filebeat
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.

--- a/cookbooks/copyleft-elkstack/recipes/kibana.rb
+++ b/cookbooks/copyleft-elkstack/recipes/kibana.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: kibana
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+package 'kibana'
+
+template 'kibana.yml' do
+  path '/opt/kibana/config/kibana.yml'
+  source 'kibana.yml.erb'
+end
+
+service 'kibana' do
+  action [:enable, :start]
+end

--- a/cookbooks/copyleft-elkstack/recipes/logstash.rb
+++ b/cookbooks/copyleft-elkstack/recipes/logstash.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: logstash
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+package 'logstash'
+
+template '02-input-beats.conf' do
+  path '/etc/logstash/conf.d/02-input-beats.conf'
+  source 'logstash/02-input-beats.conf.erb'
+end
+
+template '50-filter-syslog.conf' do
+  path '/etc/logstash/conf.d/50-filter-syslog.conf'
+  source 'logstash/50-filter-syslog.conf.erb'
+end
+
+template '90-output-elastic.conf' do
+  path '/etc/logstash/conf.d/90-output-elastic.conf'
+  source 'logstash/90-output-elastic.conf.erb'
+end
+
+service 'logstash' do
+  action [:enable, :start]
+end

--- a/cookbooks/copyleft-elkstack/recipes/topbeat.rb
+++ b/cookbooks/copyleft-elkstack/recipes/topbeat.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Recipe:: topbeat
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.

--- a/cookbooks/copyleft-elkstack/spec/spec_helper.rb
+++ b/cookbooks/copyleft-elkstack/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/default_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'creates 3 yum repos for Elastic products'
+    it 'installs the logstash package'
+    it 'installs the kibana package'
+    it 'Configures logstash diverts for filebeats data into the elasticsearch \
+      service'
+    it 'starts the logstash service'
+    it 'configures kibana to read data from elasticsearch'
+    it 'starts the kibana service'
+  end
+end

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/elasticsearch_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/elasticsearch_spec.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::elasticsearch' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'installs the elasticseach and JDK 8 packages' do
+      expect(chef_run).to install_package('elasticsearch')
+      expect(chef_run).to install_package('jdk')
+    end
+
+    it 'creates the elasticseach.yml file from template' do
+      expect(chef_run).to create_template('/etc/elasticsearch/elasticsearch.yml').with(
+        user: 'elasticsearch'
+        group: 'elasticsearch'
+      )
+    end
+
+    it 'Enables and starts the elasticseach service' do
+      expect(chef_run).to enable_service('elasticsearch')
+      expect(chef_run).to start_service('elasticsearch')
+    end
+  end
+end

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/filebeat_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/filebeat_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::filebeat' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/kibana_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/kibana_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::kibana' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/logstash_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/logstash_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::logstash' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/copyleft-elkstack/spec/unit/recipes/topbeat_spec.rb
+++ b/cookbooks/copyleft-elkstack/spec/unit/recipes/topbeat_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: copyleft-elkstack
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'copyleft-elkstack::topbeat' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/copyleft-elkstack/templates/default/elasticsearch.yml.erb
+++ b/cookbooks/copyleft-elkstack/templates/default/elasticsearch.yml.erb
@@ -1,0 +1,94 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please see the documentation for further information on configuration options:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
+#
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
+# cluster.name: my-application
+#
+# ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+#
+# node.name: node-1
+#
+# Add custom attributes to the node:
+#
+# node.rack: r1
+#
+# ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
+# path.data: /path/to/data
+#
+# Path to log files:
+#
+# path.logs: /path/to/logs
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+# bootstrap.mlockall: true
+#
+# Make sure that the `ES_HEAP_SIZE` environment variable is set to about half the memory
+# available on the system and that the owner of the process is allowed to use this limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+# network.host: 192.168.0.1
+network.host: <%= node[:fqdn] %>
+#
+# Set a custom port for HTTP:
+http.port: 9200
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+# discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+#
+# discovery.zen.minimum_master_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+# gateway.recover_after_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Disable starting multiple nodes on a single system:
+#
+# node.max_local_storage_nodes: 1
+#
+# Require explicit names when deleting indices:
+#
+# action.destructive_requires_name: true

--- a/cookbooks/copyleft-elkstack/templates/default/kibana.yml.erb
+++ b/cookbooks/copyleft-elkstack/templates/default/kibana.yml.erb
@@ -1,0 +1,82 @@
+# Kibana is served by a back end server. This controls which port to use.
+# server.port: 5601
+server.port: 5600
+
+# The host to bind the server to.
+# server.host: "0.0.0.0"
+server.host: "<%= node[:fqdn] %>"
+
+# If you are running kibana behind a proxy, and want to mount it at a path,
+# specify that path here. The basePath can't end in a slash.
+# server.basePath: ""
+
+# The maximum payload size in bytes on incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The Elasticsearch instance to use for all your queries.
+# elasticsearch.url: "http://localhost:9200"
+elasticsearch.url: "http://<%= node[:fqdn] %>:9200"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+# elasticsearch.preserveHost: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+# kibana.index: ".kibana"
+
+# The default application to load.
+# kibana.defaultAppId: "discover"
+
+# If your Elasticsearch is protected with basic auth, these are the user credentials
+# used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied through
+# the Kibana server)
+# elasticsearch.username: "user"
+# elasticsearch.password: "pass"
+
+# SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+# server.ssl.cert: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+# elasticsearch.ssl.cert: /path/to/your/client.crt
+# elasticsearch.ssl.key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsearch instance, put
+# the path of the pem file here.
+# elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+# elasticsearch.ssl.verify: true
+
+# Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+# request_timeout setting
+# elasticsearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+# elasticsearch.requestTimeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+# elasticsearch.shardTimeout: 0
+
+# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+# elasticsearch.startupTimeout: 5000
+
+# Set the path to where you would like the process id file to be created.
+# pid.file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# logging.dest: stdout
+
+# Set this to true to suppress all logging output.
+# logging.silent: false
+
+# Set this to true to suppress all logging output except for error messages.
+# logging.quiet: false
+
+# Set this to true to log all events, including system usage information and all requests.
+# logging.verbose: false

--- a/cookbooks/copyleft-elkstack/templates/default/logstash/02-input-beats.conf.erb
+++ b/cookbooks/copyleft-elkstack/templates/default/logstash/02-input-beats.conf.erb
@@ -1,0 +1,10 @@
+input {
+  beats {
+    port => 5044
+    ssl => true
+<% if node[:logstash][:ssl_enabled] then -%>
+    ssl_certificate => "/etc/pki/tls/certs/logstash-forwarder.crt"
+    ssl_key => "/etc/pki/tls/private/logstash-forwarder.key"
+<% end %>
+  }
+}

--- a/cookbooks/copyleft-elkstack/templates/default/logstash/50-filter-syslog.conf.erb
+++ b/cookbooks/copyleft-elkstack/templates/default/logstash/50-filter-syslog.conf.erb
@@ -1,0 +1,13 @@
+filter {
+  if [type] == "syslog" {
+    grok {
+      match => { "message" => "%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}" }
+      add_field => [ "received_at", "%{@timestamp}" ]
+      add_field => [ "received_from", "%{host}" ]
+    }
+    syslog_pri { }
+    date {
+      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+    }
+  }
+}

--- a/cookbooks/copyleft-elkstack/templates/default/logstash/90-output-elastic.conf.erb
+++ b/cookbooks/copyleft-elkstack/templates/default/logstash/90-output-elastic.conf.erb
@@ -1,0 +1,9 @@
+output {
+  elasticsearch {
+    hosts => ["<%= node['fqdn'] %>:9200"]
+    sniffing => true
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+}

--- a/cookbooks/copyleft-elkstack/test/integration/default/serverspec/default_spec.rb
+++ b/cookbooks/copyleft-elkstack/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'copyleft-elkstack::default' do
+  # Serverspec examples can be found at
+  # http://serverspec.org/resource_types.html
+  it 'does something' do
+    skip 'Replace this with meaningful tests'
+  end
+end

--- a/cookbooks/copyleft-elkstack/test/integration/helpers/serverspec/spec_helper.rb
+++ b/cookbooks/copyleft-elkstack/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
+  set :backend, :exec
+else
+  set :backend, :cmd
+  set :os, family: 'windows'
+end


### PR DESCRIPTION
The copyleft-elkstack cookbook is designed to install and configure a
basic elkstack for a 'Proof of Concept' environment. It uses a CentOS
7 base VM and install packages from Elastic's public yum repositories.

'kitchen converge' will create a virtual machine with ELK installed,
Elastic listening on  port 9200, LogStash listening for Beats formatted
messages on port 5044, and Kibana listening on port 5600.

Remove jdk artifact from copyleft-elkstack.
